### PR TITLE
Speedup brew tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ for (x in nodes) {
                             checkout scm
                         }
 
-                        docker.image("${mynode}").inside {
+                        docker.image("${mynode}").inside("-v /home/jenkins:/home/jenkins") {
                             stage("${mynode}: Prepare") {
                                 buildStatus = "PREPARING"
                                 timeout(time: 1, unit: 'HOURS') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,75 +6,70 @@ def nodes = ['biolinux:8', 'ubuntu:xenial', 'centos:6']
 for (x in nodes) {
     def mynode = x
 
-    // Create a map to pass in to the 'parallel' step so we can fire all the builds at once
-    //containers[mynode] = {
-        node('docker') {
-            timestamps {
-                try {
-                    // Set Linuxbre paths
-                    brew_home = "/home/jenkins/.linuxbrew"
-                    brew_bin = "${brew_home}/bin"
-                    kaust_tap = "${brew_home}/Library/Taps/kaust-rc/homebrew-apps"
-                    safe_path = "${brew_bin}:/usr/bin:/bin:/usr/sbin:/sbin"
+    node('docker') {
+        timestamps {
+            try {
+                // Set Linuxbre paths
+                brew_home = "/home/jenkins/.linuxbrew"
+                brew_bin = "${brew_home}/bin"
+                kaust_tap = "${brew_home}/Library/Taps/kaust-rc/homebrew-apps"
+                safe_path = "${brew_bin}:/usr/bin:/bin:/usr/sbin:/sbin"
 
-                    buildStatus = "CREATING CONTAINER"
+                buildStatus = "CREATING CONTAINER"
 
-                    docker.withRegistry('http://10.254.154.110', 'docker-registry-credentials') {
-                        stage("${mynode}: Update repo") {
-                            checkout scm
+                docker.withRegistry('http://10.254.154.110', 'docker-registry-credentials') {
+                    stage("${mynode}: Update repo") {
+                        checkout scm
+                    }
+
+                    // Let's mount Jenkins HOME so we can speedup tests
+                    docker.image("${mynode}").inside("-v /home/jenkins:/home/jenkins:rw,z") {
+                        stage("${mynode}: Prepare") {
+                            buildStatus = "PREPARING"
+                            timeout(time: 1, unit: 'HOURS') {
+                                withEnv(["PATH=${safe_path}"]) {
+                                    sh "brew tap kaust-rc/apps"
+                                    sh "chmod 644 ${kaust_tap}/*.rb"
+                                }
+                            }
                         }
 
-                        // Let's mount Jenkins HOME so we can speedup tests
-                        docker.image("${mynode}").inside("-v /home/jenkins:/home/jenkins:rw,z") {
-                            stage("${mynode}: Prepare") {
-                                buildStatus = "PREPARING"
+                        stage("${mynode}: Test") {
+                            buildStatus = "TESTING"
+
+                            def formulae = sh script: "${kaust_tap}/list.formulae", returnStdout: true
+                            println "Formulae to test: ${formulae}"
+
+                            // We CANNOT run tests in parallel because Linuxbrew complains
+                            // about multiple process trying to work on it
+                            def formulaeList = formulae.split(" ")
+                            for (f in formulaeList) {
+                                def formula = f
+
                                 timeout(time: 1, unit: 'HOURS') {
-                                    withEnv(["PATH=${safe_path}"]) {
-                                        sh "brew tap kaust-rc/apps"
-                                        sh "chmod 644 ${kaust_tap}/*.rb"
+                                    withEnv(["PATH=${safe_path}", 'HOMEBREW_DEVELOPER=1']) {
+                                        sh "brew reinstall ${formula}"
+                                        sh "brew audit --strict ${formula}"
+                                        sh "brew test ${formula}"
                                     }
                                 }
                             }
-
-                            stage("${mynode}: Test") {
-                                buildStatus = "TESTING"
-
-                                def formulae = sh script: "${kaust_tap}/list.formulae", returnStdout: true
-                                println "Formulae to test: ${formulae}"
-
-                                // We CANNOT run tests in parallel because Linuxbrew complains
-                                // about multiple process trying to work on it
-                                def formulaeList = formulae.split(" ")
-                                for (f in formulaeList) {
-                                    def formula = f
-
-                                    timeout(time: 1, unit: 'HOURS') {
-                                        withEnv(["PATH=${safe_path}", 'HOMEBREW_DEVELOPER=1']) {
-                                            sh "brew install ${formula}"
-                                            sh "brew audit --strict ${formula}"
-                                            sh "brew test ${formula}"
-                                        }
-                                    }
-                                }
-                            }
-
-                            buildStatus = "SUCCESSFUL"
                         }
+
+                        buildStatus = "SUCCESSFUL"
                     }
                 }
-                catch(e) {
-                    buildStatus = "FAILED"
-                    throw e
-                }
-                finally {
-                    notifyBuild(mynode, buildStatus)
-                }
+            }
+            catch(e) {
+                buildStatus = "FAILED"
+                throw e
+            }
+            finally {
+                notifyBuild(mynode, buildStatus)
             }
         }
-    //}
+    }
 }
-
-//parallel containers
 
 def notifyBuild(String nodeName, String buildStatus) {
     // Default values

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,7 @@ for (x in nodes) {
         node('docker') {
             timestamps {
                 try {
+                    // Set Linuxbre paths
                     brew_home = "/home/jenkins/.linuxbrew"
                     brew_bin = "${brew_home}/bin"
                     kaust_tap = "${brew_home}/Library/Taps/kaust-rc/homebrew-apps"
@@ -23,6 +24,7 @@ for (x in nodes) {
                             checkout scm
                         }
 
+                        // Let's mount Jenkins HOME so we can speedup tests
                         docker.image("${mynode}").inside("-v /home/jenkins:/home/jenkins:rw,z") {
                             stage("${mynode}: Prepare") {
                                 buildStatus = "PREPARING"
@@ -39,11 +41,11 @@ for (x in nodes) {
                                 buildStatus = "TESTING"
 
                                 def formulae = sh script: "${kaust_tap}/list.formulae", returnStdout: true
-
                                 println "Formulae to test: ${formulae}"
 
+                                // We CANNOT run tests in parallel because Linuxbrew complains
+                                // about multiple process trying to work on it
                                 def formulaeList = formulae.split(" ")
-
                                 for (f in formulaeList) {
                                     def formula = f
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,13 @@
 #!groovy
 
 def nodes = ['biolinux:8', 'ubuntu:xenial', 'centos:6']
-def containers = [:]
+//def containers = [:]
 
 for (x in nodes) {
     def mynode = x
 
     // Create a map to pass in to the 'parallel' step so we can fire all the builds at once
-    containers[mynode] = {
+    //containers[mynode] = {
         node('docker') {
             timestamps {
                 try {
@@ -30,11 +30,10 @@ for (x in nodes) {
                                 buildStatus = "PREPARING"
                                 timeout(time: 1, unit: 'HOURS') {
                                     withEnv(["PATH=${safe_path}"]) {
-                                        sh "brew update || brew update"
                                         sh "brew tap kaust-rc/apps"
+                                        sh "chmod 644 ${kaust_tap}/*.rb"
                                     }
                                 }
-                                sh "chmod 644 ${kaust_tap}/*.rb"
                             }
 
                             stage("${mynode}: Test") {
@@ -72,10 +71,10 @@ for (x in nodes) {
                 }
             }
         }
-    }
+    //}
 }
 
-parallel containers
+//parallel containers
 
 def notifyBuild(String nodeName, String buildStatus) {
     // Default values

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,8 @@ for (x in nodes) {
                                 timeout(time: 1, unit: 'HOURS') {
                                     withEnv(["PATH=${safe_path}", 'HOMEBREW_DEVELOPER=1']) {
                                         sh "brew reinstall ${formula}"
-                                        sh "brew audit --strict ${formula}"
+                                        // sh "brew audit --strict ${formula}"
+                                        sh "brew audit ${formula}"
                                         sh "brew test ${formula}"
                                     }
                                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,15 +1,13 @@
 #!groovy
 
 def nodes = ['biolinux:8', 'ubuntu:xenial', 'centos:6']
-//def containers = [:]
-
 for (x in nodes) {
     def mynode = x
 
     node('docker') {
         timestamps {
             try {
-                // Set Linuxbre paths
+                // Set Linuxbrew paths
                 brew_home = "/home/jenkins/.linuxbrew"
                 brew_bin = "${brew_home}/bin"
                 kaust_tap = "${brew_home}/Library/Taps/kaust-rc/homebrew-apps"
@@ -41,7 +39,7 @@ for (x in nodes) {
                             println "Formulae to test: ${formulae}"
 
                             // We CANNOT run tests in parallel because Linuxbrew complains
-                            // about multiple process trying to work on it
+                            // about multiple processes trying to work on it
                             def formulaeList = formulae.split(" ")
                             for (f in formulaeList) {
                                 def formula = f

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,8 +38,6 @@ for (x in nodes) {
                             stage("${mynode}: Test") {
                                 buildStatus = "TESTING"
 
-                                def formulaeToTestInParallel = [:]
-
                                 def formulae = sh script: "${kaust_tap}/list.formulae", returnStdout: true
 
                                 println "Formulae to test: ${formulae}"
@@ -49,18 +47,14 @@ for (x in nodes) {
                                 for (f in formulaeList) {
                                     def formula = f
 
-                                    formulaeToTestInParallel[formula] = {
-                                        timeout(time: 1, unit: 'HOURS') {
-                                            withEnv(["PATH=${safe_path}", 'HOMEBREW_DEVELOPER=1']) {
-                                                sh "brew install -v ${formula}"
-                                                sh "brew audit --strict ${formula}"
-                                                sh "brew test ${formula}"
-                                            }
+                                    timeout(time: 1, unit: 'HOURS') {
+                                        withEnv(["PATH=${safe_path}", 'HOMEBREW_DEVELOPER=1']) {
+                                            sh "brew install -v ${formula}"
+                                            sh "brew audit --strict ${formula}"
+                                            sh "brew test ${formula}"
                                         }
                                     }
                                 }
-
-                                parallel formulaeToTestInParallel
                             }
 
                             buildStatus = "SUCCESSFUL"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,8 +51,8 @@ for (x in nodes) {
                                     timeout(time: 1, unit: 'HOURS') {
                                         withEnv(["PATH=${safe_path}", 'HOMEBREW_DEVELOPER=1']) {
                                             sh "brew install ${formula}"
-                                            sh "brew audit ${formula}"
-                                            sh "brew test ${formula} --verbose"
+                                            sh "brew audit --strict ${formula}"
+                                            sh "brew test ${formula}"
                                         }
                                     }
                                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,9 +49,9 @@ for (x in nodes) {
 
                                     timeout(time: 1, unit: 'HOURS') {
                                         withEnv(["PATH=${safe_path}", 'HOMEBREW_DEVELOPER=1']) {
-                                            sh "brew install -v ${formula}"
-                                            sh "brew audit --strict ${formula}"
-                                            sh "brew test ${formula}"
+                                            sh "brew install ${formula}"
+                                            sh "brew audit ${formula}"
+                                            sh "brew test ${formula} --verbose"
                                         }
                                     }
                                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ for (x in nodes) {
                             checkout scm
                         }
 
-                        docker.image("${mynode}").inside("-v /home/jenkins:/home/jenkins") {
+                        docker.image("${mynode}").inside("-v /home/jenkins:/home/jenkins:rw,z") {
                             stage("${mynode}: Prepare") {
                                 buildStatus = "PREPARING"
                                 timeout(time: 1, unit: 'HOURS') {

--- a/vasp-raman.rb
+++ b/vasp-raman.rb
@@ -5,9 +5,9 @@ class VaspRaman < Formula
   version "0.6.0"
   sha256 "00b9e15a2a277299ae1093915bcd9cf6f4f70d26f47acd289055502bd1efcd0c"
 
-  depends_on "python"
-
   bottle :unneeded
+
+  depends_on "python"
 
   def install
     bin.install "vasp_raman.py"

--- a/weather.rb
+++ b/weather.rb
@@ -1,12 +1,12 @@
 class Weather < Formula
-  desc "A command line tool to retrieve local weather"
+  desc "Command-line tool to retrieve local weather"
   homepage "https://github.com/TheHipbot/weather"
   url "https://github.com/TheHipbot/weather/raw/master/archive/weather-1.0.0.tar.gz"
   sha256 "b1c7ab25dfb4530a5e35aa690d79469de5ec419dd284f03868935c2417e1ee3a"
 
-  depends_on "curl"
-
   bottle :unneeded
+
+  depends_on "curl"
 
   def install
     bin.install "weather"

--- a/xcrysden.rb
+++ b/xcrysden.rb
@@ -1,14 +1,14 @@
 class Xcrysden < Formula
-  desc "XCrySDen is a crystalline and molecular structure visualisation program aiming at display of isosurfaces and contours, which can be superimposed on crystalline structures and interactively rotated and manipulated."
+  desc "Crystalline and molecular structure visualisation program aiming at display of isosurfaces and contours."
   homepage "http://www.xcrysden.org/"
   url "http://www.xcrysden.org/download/xcrysden-1.5.60-linux_x86_64-semishared.tar.gz"
   sha256 "24e78f984d1ddae6d53f360639202e13782684a186b8a07c83d0c82471698553"
 
   bottle :unneeded
-  
+
   depends_on "tcl-tk"
   depends_on "fftw"
-  
+
   def install
     prefix.install Dir["*"]
     (bin/"xcrysden").write <<-EOS.undent


### PR DESCRIPTION
Sorry for all the spam, commits, tests and trials. Unfortunately I couldn't test this locally. I finally got this working. These are the main points:

- Install Linuxbrew on Jenkins slave (we might want to install a cron job to keep it updated)
- Load our containers with Jenkins HOME as a volume
- Remove running parallel builds since Linuxbrew doesn't like being messed around by multiple processes
- Remove build we're not interested at the moment (Trusty & CentOS 7)
- Run test phases from test-bot that we're interested in
  - Reinstall formula to test
  - Run audit on it (to add --strict once merged; this makes sure it's good for Brew core/science)
  - Run test on it
- Fix formulae so they pass strict audit