### PR TITLE
Search for KAUST_SKIP keyword to avoid building/tesing on an OS.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ for (x in nodes) {
                             sh script: "scripts/tap.kaust.apps.sh"
 
                             buildStatus = "TESTING"
-                            def formulae = sh script: "scripts/list.formulae", returnStdout: true
+                            def formulae = sh script: "scripts/list.formulae ${mynode}", returnStdout: true
                             println "Formulae to test: ${formulae}"
 
                             // We CANNOT run tests in parallel because Linuxbrew complains

--- a/scripts/list.formulae
+++ b/scripts/list.formulae
@@ -2,6 +2,9 @@
 
 set -xe
 
+# OS we're testing formulae on
+os="${1:-DUMMY_OS_VALUE}"
+
 # Let's see where we're running
 myroot=$(cd "$(dirname "$0")"; pwd)
 cd "$(dirname "${myroot}")"
@@ -9,7 +12,9 @@ cd "$(dirname "${myroot}")"
 # List all formulae ending in .rb in this folder
 output=""
 for f in *.rb; do
-    output+="$(basename "${f}" .rb) "
+    if ! grep KAUST_SKIP "${f}" | grep "${os}"; then
+        output+="$(basename "${f}" .rb) "
+    fi
 done
 
 output=${output% }


### PR DESCRIPTION
@asmaahassan90 Can you please check my Pull Request?

I though of this approach:

- You have to add in a commented section (I don't want to upset brew) KAUST_SKIP
- On the same line as the keyword you can specify as many Docker images to skip
- Here's an example `#KAUST_SKIP centos:6` that will skip building/tesing on our `centos:6` image

@NasrHassanein Check this out. Chime in.