### PR TITLE
Remove stdout/stderr while grepping to avoid errors.

### DIFF
--- a/scripts/list.formulae
+++ b/scripts/list.formulae
@@ -12,7 +12,7 @@ cd "$(dirname "${myroot}")"
 # List all formulae ending in .rb in this folder
 output=""
 for f in *.rb; do
-    if ! grep KAUST_SKIP "${f}" | grep "${os}"; then
+    if ! grep KAUST_SKIP "${f}" | grep "${os}" 1>&2 2>/dev/null; then
         output+="$(basename "${f}" .rb) "
     fi
 done


### PR DESCRIPTION
@NasrHassanein please check my patch. It seems that these grep pipes emit output that breaks the build. I tests the script locally but can only confirm it once it arrives to Jenkins.